### PR TITLE
Updated old imports from samkumar/embedded-pairing

### DIFF
--- a/lang/go/bls12381/bls12381.go
+++ b/lang/go/bls12381/bls12381.go
@@ -47,7 +47,7 @@ import (
 	"math/big"
 	"unsafe"
 
-	"github.com/samkumar/embedded-pairing/lang/go/internal"
+	"github.com/ucbrise/jedi-pairing/lang/go/internal"
 	"golang.org/x/crypto/sha3"
 )
 

--- a/lang/go/cryptutils/utils.go
+++ b/lang/go/cryptutils/utils.go
@@ -47,8 +47,8 @@ import (
 
 	"golang.org/x/crypto/sha3"
 
-	"github.com/samkumar/embedded-pairing/lang/go/bls12381"
-	"github.com/samkumar/embedded-pairing/lang/go/internal"
+	"github.com/ucbrise/jedi-pairing/lang/go/bls12381"
+	"github.com/ucbrise/jedi-pairing/lang/go/internal"
 )
 
 // Encryptable represents a message that can be encrypted with WKD-IBE. The

--- a/lang/go/cryptutils/utils_test.go
+++ b/lang/go/cryptutils/utils_test.go
@@ -37,7 +37,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/samkumar/embedded-pairing/lang/go/bls12381"
+	"github.com/ucbrise/jedi-pairing/lang/go/bls12381"
 )
 
 func TestHashToZp(t *testing.T) {

--- a/lang/go/lqibe/lqibe.go
+++ b/lang/go/lqibe/lqibe.go
@@ -46,7 +46,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/samkumar/embedded-pairing/lang/go/internal"
+	"github.com/ucbrise/jedi-pairing/lang/go/internal"
 	"golang.org/x/crypto/sha3"
 )
 

--- a/lang/go/wkdibe/wkdibe.go
+++ b/lang/go/wkdibe/wkdibe.go
@@ -50,8 +50,8 @@ import (
 	"sort"
 	"unsafe"
 
-	"github.com/samkumar/embedded-pairing/lang/go/cryptutils"
-	"github.com/samkumar/embedded-pairing/lang/go/internal"
+	"github.com/ucbrise/jedi-pairing/lang/go/cryptutils"
+	"github.com/ucbrise/jedi-pairing/lang/go/internal"
 )
 
 // Params represents public parameters for a WKD-IBE system.

--- a/lang/go/wkdibe/wkdibe_test.go
+++ b/lang/go/wkdibe/wkdibe_test.go
@@ -38,8 +38,8 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/samkumar/embedded-pairing/lang/go/bls12381"
-	"github.com/samkumar/embedded-pairing/lang/go/cryptutils"
+	"github.com/ucbrise/jedi-pairing/lang/go/bls12381"
+	"github.com/ucbrise/jedi-pairing/lang/go/cryptutils"
 )
 
 func NewMessage() *cryptutils.Encryptable {


### PR DESCRIPTION
to ucbrise/jedi-pairing. This will help remove the `samkumar/embedded-pairing` import from WAVE and WAVEMQ